### PR TITLE
repos/replica: update submodule URL to absolute over HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://anongit.gentoo.org/git/proj/musl.git
 [submodule "repos/replica"]
 	path = repos/replica
-	url = git@github.com:sartura/replica-overlay-main.git
+	url = https://github.com/sartura/replica-overlay-main.git


### PR DESCRIPTION
Git submodule URLs can be either absolute (over HTTPS or SSH), or
relative, where the protocol is defined at clone time.

Using relative URLs might seem ideal, but it has some disadvantages.
Let's switch replica repository URL from absolute over SSH to HTTPS.

Signed-off-by: Jakov Petrina <jakov.petrina@sartura.hr>