### PR TITLE
targets:rpi4: implement multistrap packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,6 @@ endif
 ifneq ($(DEBOOTSTRAP_URL),)
   M4FLAGS += -D__debootstrap_url__="$(DEBOOTSTRAP_URL)"
 endif
-ifneq ($(DEBOOTSTRAP_INCLUDE),)
-  M4FLAGS += -D__debootstrap_include__="$(DEBOOTSTRAP_INCLUDE)"
-endif
-ifneq ($(DEBOOTSTRAP_EXCLUDE),)
-  M4FLAGS += -D__debootstrap_exclude__="$(DEBOOTSTRAP_EXCLUDE)"
-endif
 ifneq ($(DDR_TOPOLOGY),)
   M4FLAGS += -D__atf_ddr_topology__="$(DDR_TOPOLOGY)"
 endif

--- a/repos/debian/rpi4/config/multistrap.conf
+++ b/repos/debian/rpi4/config/multistrap.conf
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2021 Sartura Ltd.
+#
+# Multistrap configuration
+#
+[General]
+noauth=true
+cleanup=true
+setupscript=/usr/share/multistrap/chroot.sh
+addimportant=true
+multiarch=arm64
+#bootstrap=Debian Foreign
+bootstrap=Debian
+aptsources=Debian
+
+[Debian]
+source=http://deb.debian.org/debian/
+keyring=debian-archive-keyring
+components=main contrib non-free
+omitdebsrc=true
+suite=stable
+
+packages= systemd udev kmod apt lsb-release
+packages= firmware-brcm80211 iw
+
+# Example of third party source usage
+#
+# [Foreign]
+# source=https://download.docker.com/linux/debian
+# suite=bullseye
+# packages= docker-ce docker-ce-cli containerd.io

--- a/targets/rpi4.docker
+++ b/targets/rpi4.docker
@@ -12,8 +12,6 @@ include(`modules/system.docker')dnl
 
 setdef(`__debootstrap_release__', `stable')dnl
 setdef(`__debootstrap_url__',     `http://deb.debian.org/debian/')dnl
-setdef(`__debootstrap_dinclude__', `gpg,dirmngr,debian-keyring,fancontrol,firmware-brcm80211,')dnl
-setdef(`__debootstrap_include__', `')dnl
 
 setdef(`__kernel_remote__', `https://github.com/raspberrypi/linux.git')dnl
 setdef(`__kernel_branch__', `rpi-5.10.y')dnl
@@ -40,30 +38,34 @@ include(`modules/configure.docker')dnl
 
 ifelse(index(_TDISTRO_, `debian'),0,`dnl
 RUN __renv__ __rdistfiles__ __rccache__ \
-    mv ${SYSROOT}/boot          /usr/src/boot && \
-    mv ${SYSROOT}/lib/modules   /usr/src/modules && \
-    rm -rf                      ${SYSROOT}/* && \
     debootstrap \
-        --arch=${TPARCH} \
-        --no-merged-usr \
         --cache-dir=/var/cache/distfiles \
-        --components="main,contrib,non-free" \
-        --include="__debootstrap_dinclude__ __debootstrap_include__"\
-ifdef(`__debootstrap_exclude__', `dnl
-        --exclude="__debootstrap_exclude__" \
-')dnl
-        "__debootstrap_release__" ${SYSROOT} "__debootstrap_url__" || ( cat ${SYSROOT}/debootstrap/debootstrap.log; exit 1 )
-    
+        --include="gpg,dirmngr,debian-keyring,ca-certificates,multistrap" \
+        "__debootstrap_release__" /var/tmp/ds/ "__debootstrap_url__" && \
+    sed -i "/Install-Recommends=false/ s|$|;\n\$config_str .= \" -o Acquire::AllowInsecureRepositories=yes\"|" \
+        /var/tmp/ds/usr/sbin/multistrap
+
+COPY ./repos/debian/rpi4/config/multistrap.conf /var/tmp/ds
+
 RUN __renv__ __rdistfiles__ __rccache__ \
+    mv ${SYSROOT}/boot          /var/tmp/boot && \
+    mv ${SYSROOT}/lib/modules   /var/tmp/modules && \
+    #
+    rm -rf ${SYSROOT}/* && \
+    chroot /var/tmp/ds multistrap -a ${TPARCH} -d /ms -f /multistrap.conf && \
+    mv -f /var/tmp/ds/ms/* ${SYSROOT}/ && \
+    #
+    mv -f /var/tmp/modules           ${SYSROOT}/lib/  && \
+    mv -f /var/tmp/boot/*            ${SYSROOT}/boot/ && \
     git clone --depth=1 --branch "__firmware_branch__" __firmware_remote__ \
-        /usr/src/firmware && rm -rf /usr/src/firmware/.git && \
-    cp -r /usr/src/firmware/boot/* ${SYSROOT}/boot/ && \
-    sed -i "s/root:\*:/root\:\$6\$MIf334fS6fTaKihG\$FAoUg\.iIq0WSq\.zZ\.UZ70HrACKRkv9ZGBucyOsXk8hZpqCbkfdo7x\/UVhq7L5Lzd5HTNINQTCcAXttuqSBe070:/" \
-        ${SYSROOT}/etc/shadow && \
-    mv -f /usr/src/boot/*         ${SYSROOT}/boot/ && \
-    mv -f /usr/src/modules      ${SYSROOT}/lib/ && \
-    cp -f ${SYSROOT}/lib/systemd/resolv.conf ${SYSROOT}/etc/ && \
-    chroot ${SYSROOT} systemctl preset-all
+        /var/tmp/firmware && rm -rf /var/tmp/firmware/.git && \
+    cp -r /var/tmp/firmware/boot/*   ${SYSROOT}/boot/ && \
+    #
+    cp -f /var/tmp/ds/etc/{passwd,group}     ${SYSROOT}/etc && \
+    cp -f ${SYSROOT}/lib/systemd/resolv.conf ${SYSROOT}/etc && \
+    LC_ALL=C LANGUAGE=C LANG=C DEBIAN_FRONTEND=noninteractive \
+        chroot ${SYSROOT} dpkg --configure --pending --force-configure-any --force-depends && \
+    gawk -i inplace "BEGIN{OFS=FS=\":\"}; \$1==\"root\" {\$2=\"$(openssl passwd -6 replica)\"}{print}" ${SYSROOT}/etc/shadow
 ')dnl
 
 # Copy system policies from the Docker context

--- a/targets/rpi4.package
+++ b/targets/rpi4.package
@@ -28,7 +28,7 @@ fi
 
 # Generate and partition a relatively large image
 # TODO: Research a better way to do this, without wasted space and large files.
-fallocate -l 2048M ${OIMG}
+fallocate -l 4096M ${OIMG}
 sed -e 's/\s*\([\+0-9a-zA-Z]*\).*/\1/' << EOF | fdisk ${OIMG}
   o # clear the in memory partition table
   n # new partition


### PR DESCRIPTION
This change adds the option to build a fully custom rpi4 debian image based on multistrap.

This implementation is still experimental, and does not guarantee a working system.

Signed-off-by: Alen Jelavic <alen.jelavic@sartura.hr>