### PR TITLE
weekly-update: remove user-provided GitHub Actions

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -3,39 +3,39 @@ on:
   schedule:
     - cron: '0 5 ? * THU'
   workflow_dispatch:
-    
+
 jobs:
   weekly-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: peterjgrainger/action-create-branch@v2.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          branch: 'weekly/update'
-      
       - uses: actions/checkout@v2.4.0
-        with: 
-          ref: 'weekly/update'
-          submodules: 'recursive'
+        with:
+            ref: 'main'
+            submodules: 'recursive'
+        
+      - run: |
+          git checkout -b weekly/update main
+          echo "DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
       
-      - run: echo "DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
-      
-      - run: | 
+      - run: |
           sed -i -e "s/GENTOO_TAG := [0-9]*$/GENTOO_TAG := ${{ env.DATE }}/" Makefile
           git submodule update --recursive --remote
-      
-      - uses: crazy-max/ghaction-import-gpg@v4
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-      
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Update Gentoo stage3 and repositories to ${{ env.DATE }}
-          commit_options: '--signoff'
-          commit_user_name: Sartura Bot
-          commit_user_email: replica@sartura.hr
-          commit_author: Sartura Bot <replica@sartura.hr>
+
+      - run: |
+          echo "$GPG_PRIV_KEY" > /home/runner/private.gpg 
+          gpg --import --batch /home/runner/private.gpg 
+          (echo 5; echo y; echo save) | gpg --command-fd 0 --no-tty --no-greeting -q --edit-key "$( gpg --list-packets /home/runner/private.gpg | awk '$1=="keyid:"{print$2;exit}')" trust
+          echo "KEY_ID=$(gpg --list-secret-keys --keyid-format=long | grep sec | grep -o -P '(?<=/)[A-Z0-9]{16}')" >> $GITHUB_ENV
+        env:
+          GPG_PRIV_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - run: |
+          echo "$GPG_PASS" | gpg --passphrase-fd 0 --pinentry-mode loopback --status-fd=2 -bsau "$KEY_ID"
+          git config user.signingkey "$KEY_ID"
+          git config user.name "Sartura Bot"
+          git config user.email "replica@sartura.hr"
+          git add .
+          git commit -s -S -m "Update Gentoo stage3 and repositories to ${{ env.DATE }}"
+          git push -f origin weekly/update
+        env:
+          GPG_PASS: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
This change removes third party user-provided GitHub Actions used in the weekly-update workflow.

Signed-off-by: Alen Jelavic <alen.jelavic@sartura.hr>